### PR TITLE
#26 - 選択肢Propsの受け取り方を修正

### DIFF
--- a/src/component/Selection.tsx
+++ b/src/component/Selection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   SafeAreaView,
   StyleSheet,
@@ -9,8 +9,7 @@ import {
 import { AnswerProps } from '../interface/components';
 
 export const Selection = (props: AnswerProps) => {
-  const { checkAnswer } = props;
-  const [selections, setSelections] = useState(props.selections);
+  const { checkAnswer, selections } = props;
 
   return (
     <SafeAreaView>

--- a/src/screen/Answer.tsx
+++ b/src/screen/Answer.tsx
@@ -47,7 +47,6 @@ export const Answer = (props: any) => {
     });
   }
   
-  
   return (
       <View style={styles.container}>
         {questions.length - 1 >= count ? (


### PR DESCRIPTION
### #26 の原因
- Selectionコンポーネントでの選択肢データの受け取り方が、useStateを使用したものになっていた
- Stateを変更する処理を記載しなければ更新されなかったので、問題が変更されても選択肢はそのままになっていた

### 変更内容
- useStateを使用せずに、受け取ったpropsをそのまま表示する様に変更
  - ユーザーが回答したら親コンポーネントが再レンダリングされる様になっているので、Stateで保存する必要がないため